### PR TITLE
rename overlap to spacing in chunkadelic, update help

### DIFF
--- a/03_chunkadelic.ipynb
+++ b/03_chunkadelic.ipynb
@@ -109,6 +109,8 @@
     "        print(f\"normalizing {new_filename} with type {norm}\")\n",
     "        audio = normalize_audio(audio, norm)\n",
     "    \n",
+    "    spacing = 0.5 if spacing is 0 else spacing # handle degenerate case as a request for the defaults\n",
+    "    \n",
     "    start, i = 0, 0\n",
     "    while start < audio.shape[-1]:\n",
     "        out_filename = new_filename.replace(ext, f'--{i}'+ext) \n",

--- a/03_chunkadelic.ipynb
+++ b/03_chunkadelic.ipynb
@@ -94,7 +94,7 @@
     "    chunk_size:int,      # how big each audio chunk is, in samples\n",
     "    sr=48000,            # audio sample rate in Hz\n",
     "    norm=False,          # normalize audio, based on the max of the absolute value [global/channel]\n",
-    "    overlap=0.5,         # fraction of each chunk to overlap between hops\n",
+    "    spacing=0.5,         # fraction of each chunk to advance between hops\n",
     "    strip=False,    # strip silence: chunks with max power in dB below this value will not be saved to files\n",
     "    thresh=-70      # threshold in dB for determining what counts as silence \n",
     "    ):\n",
@@ -120,7 +120,7 @@
     "            torchaudio.save(out_filename, chunk, sr)\n",
     "        else:\n",
     "            print(f\"skipping chunk {out_filename} because it's 'silent' (below threhold of {thresh} dB).\",flush=True)\n",
-    "        start, i = start + int(overlap * chunk_size), i + 1\n",
+    "        start, i = start + int(spacing * chunk_size), i + 1\n",
     "    return "
    ]
   },
@@ -156,7 +156,7 @@
     "        return \n",
     "    try:\n",
     "        audio = load_audio(filename, sr=args.sr)\n",
-    "        blow_chunks(audio, new_filename, args.chunk_size, sr=args.sr, norm=args.norm, overlap=args.overlap, strip=args.strip, thresh=args.thresh)\n",
+    "        blow_chunks(audio, new_filename, args.chunk_size, sr=args.sr, norm=args.norm, spacing=args.spacing, strip=args.strip, thresh=args.thresh)\n",
     "    except Exception as e: \n",
     "        print(f\"Error loading {filename} or writing chunks. Skipping.\", flush=True)\n",
     "\n",
@@ -175,8 +175,8 @@
     "    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)\n",
     "    parser.add_argument('--chunk_size', type=int, default=2**17, help='Length of chunks')\n",
     "    parser.add_argument('--sr', type=int, default=48000, help='Output sample rate')\n",
-    "    parser.add_argument('--norm', action='store_true', help='normalize audio, based on the max of the absolute value [global/channel]')\n",
-    "    parser.add_argument('--overlap', type=float, default=0.5, help='Overlap factor')\n",
+    "    parser.add_argument('--norm', action='store_true', help='Normalize audio, based on the max of the absolute value [global/channel]')\n",
+    "    parser.add_argument('--spacing', type=float, default=0.5, help='Spacing factor, advance this fraction of a chunk per copy')\n",
     "    parser.add_argument('--strip', action='store_true', help='Strips silence: chunks with max dB below <thresh> are not outputted')\n",
     "    parser.add_argument('--thresh', type=int, default=-70, help='threshold in dB for determining what constitutes silence')\n",
     "    parser.add_argument('--workers', type=int, default=min(32, os.cpu_count() + 4), help='Maximum number of workers to use (default: all)')\n",
@@ -210,8 +210,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: chunkadelic [-h] [--chunk_size CHUNK_SIZE] [--sr SR]\r\n",
-      "                   [--overlap OVERLAP] [--strip] [--thresh THRESH]\r\n",
+      "usage: chunkadelic [-h] [--chunk_size CHUNK_SIZE] [--sr SR] [--norm]\r\n",
+      "                   [--spacing SPACING] [--strip] [--thresh THRESH]\r\n",
       "                   [--workers WORKERS] [--nomix]\r\n",
       "                   output_path input_paths [input_paths ...]\r\n",
       "\r\n",
@@ -224,13 +224,16 @@
       "  --chunk_size CHUNK_SIZE\r\n",
       "                        Length of chunks (default: 131072)\r\n",
       "  --sr SR               Output sample rate (default: 48000)\r\n",
-      "  --overlap OVERLAP     Overlap factor (default: 0.5)\r\n",
+      "  --norm                Normalize audio, based on the max of the absolute\r\n",
+      "                        value [global/channel] (default: False)\r\n",
+      "  --spacing SPACING     Spacing factor, advance this fraction of a chunk per\r\n",
+      "                        copy (default: 0.5)\r\n",
       "  --strip               Strips silence: chunks with max dB below <thresh> are\r\n",
       "                        not outputted (default: False)\r\n",
       "  --thresh THRESH       threshold in dB for determining what constitutes\r\n",
       "                        silence (default: -70)\r\n",
       "  --workers WORKERS     Maximum number of workers to use (default: all)\r\n",
-      "                        (default: 14)\r\n",
+      "                        (default: 5)\r\n",
       "  --nomix               (BDCT Dataset specific) exclude output of \"*/Audio\r\n",
       "                        Files/*Mix*\" (default: False)\r\n"
      ]
@@ -263,7 +266,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python 3 (ipykernel)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   }

--- a/aeiou/chunkadelic.py
+++ b/aeiou/chunkadelic.py
@@ -21,7 +21,7 @@ def blow_chunks(
     chunk_size:int,      # how big each audio chunk is, in samples
     sr=48000,            # audio sample rate in Hz
     norm=False,          # normalize audio, based on the max of the absolute value [global/channel]
-    overlap=0.5,         # fraction of each chunk to overlap between hops
+    spacing=0.5,         # fraction of each chunk to advance between hops
     strip=False,    # strip silence: chunks with max power in dB below this value will not be saved to files
     thresh=-70      # threshold in dB for determining what counts as silence 
     ):
@@ -47,7 +47,7 @@ def blow_chunks(
             torchaudio.save(out_filename, chunk, sr)
         else:
             print(f"skipping chunk {out_filename} because it's 'silent' (below threhold of {thresh} dB).",flush=True)
-        start, i = start + int(overlap * chunk_size), i + 1
+        start, i = start + int(spacing * chunk_size), i + 1
     return 
 
 # %% ../03_chunkadelic.ipynb 8
@@ -75,7 +75,7 @@ def process_one_file(
         return 
     try:
         audio = load_audio(filename, sr=args.sr)
-        blow_chunks(audio, new_filename, args.chunk_size, sr=args.sr, norm=args.norm, overlap=args.overlap, strip=args.strip, thresh=args.thresh)
+        blow_chunks(audio, new_filename, args.chunk_size, sr=args.sr, norm=args.norm, spacing=args.spacing, strip=args.strip, thresh=args.thresh)
     except Exception as e: 
         print(f"Error loading {filename} or writing chunks. Skipping.", flush=True)
 
@@ -86,8 +86,8 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--chunk_size', type=int, default=2**17, help='Length of chunks')
     parser.add_argument('--sr', type=int, default=48000, help='Output sample rate')
-    parser.add_argument('--norm', action='store_true', help='normalize audio, based on the max of the absolute value [global/channel]')
-    parser.add_argument('--overlap', type=float, default=0.5, help='Overlap factor')
+    parser.add_argument('--norm', action='store_true', help='Normalize audio, based on the max of the absolute value [global/channel]')
+    parser.add_argument('--spacing', type=float, default=0.5, help='Spacing factor, advance this fraction of a chunk per copy')
     parser.add_argument('--strip', action='store_true', help='Strips silence: chunks with max dB below <thresh> are not outputted')
     parser.add_argument('--thresh', type=int, default=-70, help='threshold in dB for determining what constitutes silence')
     parser.add_argument('--workers', type=int, default=min(32, os.cpu_count() + 4), help='Maximum number of workers to use (default: all)')

--- a/aeiou/chunkadelic.py
+++ b/aeiou/chunkadelic.py
@@ -36,6 +36,8 @@ def blow_chunks(
         print(f"normalizing {new_filename} with type {norm}")
         audio = normalize_audio(audio, norm)
     
+    spacing = 0.5 if spacing is 0 else spacing # handle degenerate case as a request for the defaults
+    
     start, i = 0, 0
     while start < audio.shape[-1]:
         out_filename = new_filename.replace(ext, f'--{i}'+ext) 


### PR DESCRIPTION
As discussed, also fixes the errantly named notebook kernel name.