### PR TITLE
Add get_audio_filenames to spectrofu

### DIFF
--- a/04_spectrofu.ipynb
+++ b/04_spectrofu.ipynb
@@ -80,7 +80,7 @@
     "from tqdm.contrib.concurrent import process_map  \n",
     "import torch\n",
     "import torchaudio\n",
-    "from aeiou.core import is_silence, load_audio, makedir\n",
+    "from aeiou.core import is_silence, load_audio, makedir, get_audio_filenames\n",
     "from aeiou.viz import audio_spectrogram_image"
    ]
   },

--- a/aeiou/spectrofu.py
+++ b/aeiou/spectrofu.py
@@ -14,7 +14,7 @@ from functools import partial
 from tqdm.contrib.concurrent import process_map  
 import torch
 import torchaudio
-from .core import is_silence, load_audio, makedir
+from .core import is_silence, load_audio, makedir, get_audio_filenames
 from .viz import audio_spectrogram_image
 
 # %% ../04_spectrofu.ipynb 7


### PR DESCRIPTION
Fixes
**spectrofu ./output/ ./**
`  output_path = ./output/
Getting list of input filenames
Traceback (most recent call last):
  File "/home/aeiou/bin/spectrofu", line 11, in <module>
    load_entry_point('aeiou', 'console_scripts', 'spectrofu')()
  File "/home/repos/aeiou/aeiou/spectrofu.py", line 75, in main
    filenames = get_audio_filenames(args.input_paths) `
**NameError: name 'get_audio_filenames' is not defined**
