### PR TITLE
allow figsize pass to audio_spectrogram_image

### DIFF
--- a/aeiou/viz.py
+++ b/aeiou/viz.py
@@ -306,11 +306,11 @@ def spectrogram_image(
     return im
 
 # %% ../02_viz.ipynb 27
-def audio_spectrogram_image(waveform, power=2.0, sample_rate=48000, print=print, db=False, db_range=[35,120], justimage=False, log=False):
+def audio_spectrogram_image(waveform, power=2.0, sample_rate=48000, print=print, db=False, db_range=[35,120], justimage=False, log=False, figsize=(5, 4)):
     "Wrapper for calling above two routines at once, does Mel scale; Modified from PyTorch tutorial https://pytorch.org/tutorials/beginner/audio_feature_extractions_tutorial.html"
     melspec = mel_spectrogram(waveform, power=power, db=db, sample_rate=sample_rate, debug=log)
     melspec = melspec[0] # TODO: only left channel for now
-    return spectrogram_image(melspec, title="MelSpectrogram", ylabel='mel bins (log freq)', db_range=db_range, justimage=justimage)
+    return spectrogram_image(melspec, title="MelSpectrogram", ylabel='mel bins (log freq)', db_range=db_range, justimage=justimage, figsize=figsize)
 
 # %% ../02_viz.ipynb 31
 # Original code by Scott Condron (@scottire) of Weights and Biases, edited by @drscotthawley


### PR DESCRIPTION
`spectrogram_image` allows passing an optional figsize, but that arg is not propagated to the `audio_spectrogram_image` wrapper. This edit lets you control that directly, for example if you want wider spectrograms: `wandb.Image(audio_spectrogram_image(fakes, figsize=(15, 4)))`